### PR TITLE
Fix bug when running in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:2.7-slim
 
 # Update Repos
 RUN apt-get update \
-  && apt-get install -qq -y --no-install-recommends build-essential sudo git wget curl \
+  && apt-get install -qq -y --no-install-recommends build-essential sudo git wget curl nmap\
   && apt-get clean
 
 # Install Python dependecies

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:2.7-slim
 
 # Update Repos
 RUN apt-get update \
-  && apt-get install -qq -y --no-install-recommends build-essential sudo git wget curl nmap\
+  && apt-get install -qq -y --no-install-recommends build-essential sudo git wget curl nmap \
   && apt-get clean
 
 # Install Python dependecies

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,18 @@
 FROM python:2.7-slim
 
 # Update Repos
-RUN apt-get update && apt-get install -qq -y --no-install-recommends \
-    build-essential git sudo wget curl
+RUN apt-get update \
+  && apt-get install -qq -y --no-install-recommends build-essential sudo git wget curl \
+  && apt-get clean
 
 # Install Python dependecies
 RUN pip install requests
 
-# Git fsociety
-RUN git clone https://github.com/Manisso/fsociety.git
-
 # Install fsociety
-RUN cd fsociety && chmod +x install.sh && ./install.sh
+RUN git clone https://github.com/Manisso/fsociety.git \
+  && cd fsociety \
+  && chmod +x install.sh \
+  && ./install.sh
 
-# Remove fsociety install folder
-RUN rm -rf fsociety
-
-# Run fsociety
-RUN fsociety
+# Hack to keep the container running
+CMD /bin/sleep 365d

--- a/README.md
+++ b/README.md
@@ -134,8 +134,9 @@ Or Use Google Cloud Console [Cloud Shell](https://console.cloud.google.com/cloud
 
 ```bash
 docker-compose build
-
-docker-compose run --rm fsociety fsociety
+docker-compose up -d
+docker-compose exec fsociety fsociety
+docker-compose down # destroys instance
 ```
 
 # Use

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,3 @@ version: '2'
 services:
   fsociety:
     build: .
-    command: bash fsociety


### PR DESCRIPTION
The major change here is adding /bin/sleep as the command to run when the image is initiated. 
 Sleep now becomes The Main process in the container.  This lets you bring the container up in the background without it exiting, then meanwhile you can open shells or run the fsociety command against it.  It's all a hack, but it works ;)

Tested on OSX and 16.04 with docker 17.09.0-ce and docker-compose 1.16.1