### PR TITLE
Change workdir in Dockerfile for nmap log path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,8 @@ RUN git clone https://github.com/Manisso/fsociety.git \
   && chmod +x install.sh \
   && ./install.sh
 
+# Change workdir
+WORKDIR /root/.fsociety/
+
 # Hack to keep the container running
 CMD python -c "import signal; signal.pause()"


### PR DESCRIPTION
Hello, when using nmap, `fsociety` has to be launched from `/root/.fsociety/` in order to open the path `logs/...`.

This PR adds the `WORKDIR` in the Dockerfile.

Cheers,

Patrik