### PR TITLE
fix setoolkit installation

### DIFF
--- a/fsociety.py
+++ b/fsociety.py
@@ -498,7 +498,7 @@ class setoolkit:
             python-pymssql build-essential python-pexpect python-pefile python-crypto python-openssl")
         os.system("git clone --depth=1 %s %s" %
                   (self.gitRepo, self.installDir))
-        os.system("python %s/setup.py install" % self.installDir)
+        os.system("cd %s && python setup.py install" % self.installDir)
 
     def run(self):
         os.system("setoolkit")


### PR DESCRIPTION
setoolkit setup.py was copying full current working directory instead of just setoolkit to /usr/share.
this causes setoolkit installation to fail.
fix is to cd to tools+setoolkit directory and invoke setup.py from there.