### PR TITLE
Fix snapcraft.yaml indentation

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,16 +1,13 @@
+name: fsociety
+version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
+summary: fsociety Hacking Tools Pack – A Penetration Testing Framework # 79 char long summary
+description: >
+  A Penetration Testing Framework, you will have every script that a hacker needs.
+  Fsociety Contains All Tools Used in Mr. Robot Series.
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
 
-  name: fsociety
-  version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
-  summary: fsociety Hacking Tools Pack – A Penetration Testing Framework # 79 char long summary
-  description: Fsociety Hacking Tools Pack
-
-A Penetration Testing Framework, you will have every script that a hacker needs
-Fsociety Contains All Tools Used in Mr. Robot Series
-  grade: devel # must be 'stable' to release into candidate/stable channels
-  confinement: devmode # use 'strict' once you have the right plugs and slots
-
-  parts:
-    my-part:
-      # See 'snapcraft plugins'
-      plugin: nil
-  
+parts:
+  my-part:
+    # See 'snapcraft plugins'
+    plugin: nil


### PR DESCRIPTION
I also removed a bit from the `description` field that just duplicated the `summary`.  (You may want to tweak this some more.)

Fixes #66.