### PR TITLE
docs: fix simple typo, trys -> tries

### DIFF
--- a/fsociety.py
+++ b/fsociety.py
@@ -1595,7 +1595,7 @@ class Fscan:
 
     def cloudflareBypasser(self):
         '''
-        trys to bypass cloudflare i already wrote
+        tries to bypass cloudflare i already wrote
         in my blog how it works, i learned this
         method from a guy in madleets
         '''


### PR DESCRIPTION
There is a small typo in fsociety.py.

Should read `tries` rather than `trys`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md